### PR TITLE
Fixed core-contributor Link

### DIFF
--- a/out/documentation/code-contributions/index.html
+++ b/out/documentation/code-contributions/index.html
@@ -82,7 +82,7 @@
 						</li>
 
 					</ul>
-		
+
 					<form class="navbar-form search-form" role="search" action="http://google.com/search" method="get">
     <div class="form-group">
         <input type="search" name="q" class="form-control" placeholder="Search">
@@ -112,7 +112,7 @@
 		<h4><a href="/documentation/getting-started">Getting Started</a><h4>
 	</li>
 
-	
+
 
 
 
@@ -120,65 +120,65 @@
 		<h4><a href="/documentation/community">Community</a><h4>
 	</li>
 
-	
-		
+
+
 			<li class= about="/documentation/community">
 				<a href="/documentation/community"> Community </a>
 			</li>
-		
+
 			<li class= about="/documentation/about">
 				<a href="/documentation/about"> About </a>
 			</li>
-		
+
 			<li class= about="/documentation/why-haxe">
 				<a href="/documentation/why-haxe"> Why a Haxe Version </a>
 			</li>
-		
+
 			<li class= about="/documentation/introduction-to-haxe">
 				<a href="/documentation/introduction-to-haxe"> Introduction to Haxe </a>
 			</li>
-		
+
 			<li class= about="/documentation/introduction-to-openfl">
 				<a href="/documentation/introduction-to-openfl"> Introduction to OpenFL </a>
 			</li>
-		
+
 			<li class= about="/documentation/contributing">
 				<a href="/documentation/contributing"> Contributing </a>
 			</li>
-		
+
 			<li class=active about="/documentation/code-contributions">
 				<a href="/documentation/code-contributions"> Code Contributions </a>
 			</li>
-		
+
 			<li class= about="/documentation/code-style">
 				<a href="/documentation/code-style"> Code Style </a>
 			</li>
-		
+
 			<li class= about="/documentation/website-docs">
 				<a href="/documentation/website-docs"> HaxeFlixel Website </a>
 			</li>
-		
+
 			<li class= about="/documentation/haxeflixel-3-x">
 				<a href="/documentation/haxeflixel-3-x"> HaxeFlixel 3.x </a>
 			</li>
-		
+
 			<li class= about="/documentation/upgrade-guide">
 				<a href="/documentation/upgrade-guide"> Upgrade Guide </a>
 			</li>
-		
+
 			<li class= about="/documentation/flixel-addons">
 				<a href="/documentation/flixel-addons"> Flixel Addons </a>
 			</li>
-		
+
 			<li class= about="/documentation/flixel-tools">
 				<a href="/documentation/flixel-tools"> Flixel Tools </a>
 			</li>
-		
+
 			<li class= about="/documentation/install-development-flixel">
 				<a href="/documentation/install-development-flixel"> Install development Flixel </a>
 			</li>
-		
-	
+
+
 
 
 
@@ -186,7 +186,7 @@
 		<h4><a href="/documentation/haxeflixel-handbook">HaxeFlixel Handbook</a><h4>
 	</li>
 
-	
+
 
 
 
@@ -194,7 +194,7 @@
 		<h4><a href="/documentation/resources">Resources</a><h4>
 	</li>
 
-	
+
 
 
 
@@ -202,7 +202,7 @@
 		<h4><a href="/documentation/tutorials">Tutorials</a><h4>
 	</li>
 
-	
+
 
 
 
@@ -213,7 +213,7 @@
 		<div class="col-md-9 doc-content" role="main">
 			<h1 class="title">Code Contributions</h1>
 
-			
+
 			<a href="https://github.com/HaxeFlixel/flixel-docs/blob/master/documentation/01_community/07-code-contributions.html.md" class="btn btn-sm btn-edit" target="_blank"><span class="glyphicon glyphicon-pencil"></span> Edit </a>
 
 			<p>Contributing code to HaxeFlixel is done all through the official git repositories on <a href="http://www.github.com/haxeflixel">GitHub</a>.</p>
@@ -222,7 +222,7 @@
 <p>To clarify: the <code>dev</code> branch on <a href="https://github.com/HaxeFlixel/flixel-addons">flixel-addons</a> and <a href="https://github.com/HaxeFlixel/flixel-demos">flixel-demos</a> is only compatible with the <code>dev</code> branch of <a href="https://github.com/HaxeFlixel/flixel">flixel</a>.</p>
 <p>If you are making changes to the codebase that could include breaking changes or a new API, we make use of the pull request feature and suggest developers use a feature branch model. <a href="https://www.atlassian.com/git/workflows#!workflow-feature-branch">Feature banches</a> are simply new branches with your code that are named with a title relating to your code.</p>
 <h3 id="merge-approval">Merge Approval</h3>
-<p>Before a major feature is merged into core our general workflow is to get approval from a <a href="https://github.com/orgs/HaxeFlixel/members">core-contributor</a> with push access.</p>
+<p>Before a major feature is merged into core our general workflow is to get approval from a <a href="https://github.com/orgs/HaxeFlixel/people">core-contributor</a> with push access.</p>
 <p>Developers do have limited time so keep in mind some simple steps to get your pull request accepted:</p>
 <ul>
 <li>Clearly describe your use case or the problem/issue your code is developed for.</li>
@@ -249,19 +249,19 @@
 			<hr>
 
 			<ul class="pager">
-				
+
 
 				<li class="previous">
 					<a href="/documentation/contributing">< Contributing</a>
 				</li>
-				
 
 
-				
+
+
 				<li class="next">
 					<a href="/documentation/code-style">Code Style ></a>
 				</li>
-				
+
 			</ul>
 
 

--- a/out/documentation/code-style/index.html
+++ b/out/documentation/code-style/index.html
@@ -82,7 +82,7 @@
 						</li>
 
 					</ul>
-		
+
 					<form class="navbar-form search-form" role="search" action="http://google.com/search" method="get">
     <div class="form-group">
         <input type="search" name="q" class="form-control" placeholder="Search">
@@ -112,7 +112,7 @@
 		<h4><a href="/documentation/getting-started">Getting Started</a><h4>
 	</li>
 
-	
+
 
 
 
@@ -120,65 +120,65 @@
 		<h4><a href="/documentation/community">Community</a><h4>
 	</li>
 
-	
-		
+
+
 			<li class= about="/documentation/community">
 				<a href="/documentation/community"> Community </a>
 			</li>
-		
+
 			<li class= about="/documentation/about">
 				<a href="/documentation/about"> About </a>
 			</li>
-		
+
 			<li class= about="/documentation/why-haxe">
 				<a href="/documentation/why-haxe"> Why a Haxe Version </a>
 			</li>
-		
+
 			<li class= about="/documentation/introduction-to-haxe">
 				<a href="/documentation/introduction-to-haxe"> Introduction to Haxe </a>
 			</li>
-		
+
 			<li class= about="/documentation/introduction-to-openfl">
 				<a href="/documentation/introduction-to-openfl"> Introduction to OpenFL </a>
 			</li>
-		
+
 			<li class= about="/documentation/contributing">
 				<a href="/documentation/contributing"> Contributing </a>
 			</li>
-		
+
 			<li class= about="/documentation/code-contributions">
 				<a href="/documentation/code-contributions"> Code Contributions </a>
 			</li>
-		
+
 			<li class=active about="/documentation/code-style">
 				<a href="/documentation/code-style"> Code Style </a>
 			</li>
-		
+
 			<li class= about="/documentation/website-docs">
 				<a href="/documentation/website-docs"> HaxeFlixel Website </a>
 			</li>
-		
+
 			<li class= about="/documentation/haxeflixel-3-x">
 				<a href="/documentation/haxeflixel-3-x"> HaxeFlixel 3.x </a>
 			</li>
-		
+
 			<li class= about="/documentation/upgrade-guide">
 				<a href="/documentation/upgrade-guide"> Upgrade Guide </a>
 			</li>
-		
+
 			<li class= about="/documentation/flixel-addons">
 				<a href="/documentation/flixel-addons"> Flixel Addons </a>
 			</li>
-		
+
 			<li class= about="/documentation/flixel-tools">
 				<a href="/documentation/flixel-tools"> Flixel Tools </a>
 			</li>
-		
+
 			<li class= about="/documentation/install-development-flixel">
 				<a href="/documentation/install-development-flixel"> Install development Flixel </a>
 			</li>
-		
-	
+
+
 
 
 
@@ -186,7 +186,7 @@
 		<h4><a href="/documentation/haxeflixel-handbook">HaxeFlixel Handbook</a><h4>
 	</li>
 
-	
+
 
 
 
@@ -194,7 +194,7 @@
 		<h4><a href="/documentation/resources">Resources</a><h4>
 	</li>
 
-	
+
 
 
 
@@ -202,7 +202,7 @@
 		<h4><a href="/documentation/tutorials">Tutorials</a><h4>
 	</li>
 
-	
+
 
 
 
@@ -213,7 +213,7 @@
 		<div class="col-md-9 doc-content" role="main">
 			<h1 class="title">Code Style</h1>
 
-			
+
 			<a href="https://github.com/HaxeFlixel/flixel-docs/blob/master/documentation/01_community/08-code-style.html.md" class="btn btn-sm btn-edit" target="_blank"><span class="glyphicon glyphicon-pencil"></span> Edit </a>
 
 			<p>This is HaxeFlixel&#39;s code style. Not the entire codebase conforms for it at the moment, but at least any new code should be written with this in mind.</p>
@@ -462,10 +462,10 @@ HaxeFlixel has changed this convention to be more like every other (Haxe) librar
 <p>Take the following comment section for example, it does not provide <em>any</em> additional value beyond what the code and the class / parameter names already tell you (one of the reasons why choosing good names is so important!). It should thus be removed completely.</p>
 <pre class="highlight"><code class="actionscript"><span class="comment">/**
  * Sets the position.
- * 
+ *
  * @param    x    The x coordinate.
  * @param    y     The y coordinate.
- */</span> 
+ */</span>
 <span class="keyword">public</span> <span class="function"><span class="keyword">function</span> <span class="title">setPosition</span><span class="params">(x:Int, y:Int)</span><span class="type">:Void</span></span></code></pre>
 <h2 id="class-names">Class names</h2>
 <p>All class names should be prefixed by <code>Flx</code>, e.g.:</p>
@@ -483,14 +483,14 @@ HaxeFlixel has changed this convention to be more like every other (Haxe) librar
 <p>The most common example where formatting is needed are the comment sections for functions:</p>
 <pre class="highlight"><code class="actionscript"><span class="comment">/**
  * Sets the position.
- * 
+ *
  * @param   x   The x coordinate.
  * @param   y   The y coordinate.
- */</span> 
+ */</span>
 <span class="keyword">public</span> <span class="function"><span class="keyword">function</span> <span class="title">setPosition</span><span class="params">(x:Int, y:Int)</span><span class="type">:Void</span></span></code></pre>
 <h2 id="position-of-metadata">Position of metadata</h2>
 <p>Metadata should always be placed in a new line for increased readability:</p>
-<pre class="highlight"><code class="actionscript">@:isVar 
+<pre class="highlight"><code class="actionscript">@:isVar
 @:allow(flixel.tweens.FlxTween)
 <span class="keyword">private</span> <span class="keyword">static</span> <span class="keyword">var</span> pool(<span class="keyword">get</span>, <span class="literal">null</span>):FlxPool&lt;MultiVarTween&gt;;</code></pre>
 <p>as opposed to:</p>
@@ -499,11 +499,13 @@ HaxeFlixel has changed this convention to be more like every other (Haxe) librar
 <p>There shouldn&#39;t be more than one empty line to separate sections.</p>
 <h2 id="using-switch-case-as-an-expression">Using switch-case as an Expression</h2>
 <p>Unlike in most other languages with object-oriented syntax, everything in Haxe is an expression. This extends to <code>switch-case</code>, meaning that it evaluates to a value. This value can be assinged to a variable, passed to a function or simply returned by a function:</p>
-<pre class="highlight"><code class="actionscript"><span class="keyword">private</span> <span class="function"><span class="keyword">function</span> <span class="title">getColor</span><span class="params">(color:Color)</span><span class="type">:Int</span> {</span>
-  <span class="keyword">return</span> <span class="keyword">switch</span> (color) {
+<pre class="highlight"><code class="actionscript"><span class="keyword">private</span> <span class="function"><span class="keyword">function</span> <span class="title">getColor</span><span class="params">(color:Color)</span><span class="type">:Int</span>
+{</span>
+  <span class="keyword">return</span> <span class="keyword">switch</span> (color)
+  {
     <span class="keyword">case</span> Color.RED: <span class="number">0xff0000</span>;
     <span class="keyword">case</span> Color.BLUE: <span class="number">0x0000ff</span>;
-    <span class="keyword">case</span> Color.GREEN: <span class="number">0x00ff00</span>;  
+    <span class="keyword">case</span> Color.GREEN: <span class="number">0x00ff00</span>;
   }
 }</code></pre>
 <p>This is preferable to how this code would look like in a lot of other languages, for example C#:</p>
@@ -524,19 +526,19 @@ HaxeFlixel has changed this convention to be more like every other (Haxe) librar
 			<hr>
 
 			<ul class="pager">
-				
+
 
 				<li class="previous">
 					<a href="/documentation/code-contributions">< Code Contributions</a>
 				</li>
-				
 
 
-				
+
+
 				<li class="next">
 					<a href="/documentation/website-docs">HaxeFlixel Website ></a>
 				</li>
-				
+
 			</ul>
 
 


### PR DESCRIPTION
Original link was pointing to https://github.com/orgs/HaxeFlixel/members and not https://github.com/orgs/HaxeFlixel/people.