### PR TITLE
Fix hljs font

### DIFF
--- a/src/documents/styles/highlighting.less
+++ b/src/documents/styles/highlighting.less
@@ -7,7 +7,6 @@ pre {
 .hljs {
   display: block;
   overflow-x: auto;
-  font-family: "Consolas";
   font-size: 12px;
 }
 


### PR DESCRIPTION
Monospace font should already be set by Bootstrap correctly. Having only consolas here looks bad when consolas is not available.