### PR TITLE
fix: update style demo page titles for Chrome

### DIFF
--- a/src/documents/styles/style.css.less
+++ b/src/documents/styles/style.css.less
@@ -187,12 +187,12 @@ pre .title:before {
 }
 
 .center-align-a {
-  position: relative;
   padding: 1em;
   text-align: center;
 }
 
 .center-align-a > a {
+  position: relative;
   padding: 14px;
   display: inline-table;
 }


### PR DESCRIPTION
This fixes the issue with titles showing up incorrectly in Chrome version 86 and above on MacOS.

**Before fix**

<img width="1202" alt="Screenshot 2020-10-20 at 17 45 00" src="https://user-images.githubusercontent.com/1377253/96618308-b0129b00-12fc-11eb-9617-3a30766f6528.png">

**After fix**
<img width="1206" alt="Screenshot 2020-10-20 at 17 48 08" src="https://user-images.githubusercontent.com/1377253/96618325-b86ad600-12fc-11eb-8383-4484197220e6.png">


Fix tested in Safari and Firefox.

