### PR TITLE
fix: firefox specific issue one demo page where layout is broken

### DIFF
--- a/src/documents/showcase.html.eco
+++ b/src/documents/showcase.html.eco
@@ -101,7 +101,7 @@ layout: showcases
 </div>
 
 
-	<div class="row">
+	<div class="row showcase-grid">
 
 		<% for showcase in @getCollection('showcase').toJSON(): %>
 

--- a/src/documents/styles/sections/showcase.less
+++ b/src/documents/styles/sections/showcase.less
@@ -13,6 +13,9 @@
   .opacityAll(.1);
 }
 
+.showcase-grid .col-md-4:nth-child(3n+1) {
+  clear: both;
+}
 .showcase-game-thumbnail img {
   .box-shadow(~"0 1px 5px #696969, 0 -2px 5px #F2F2F2");
 }


### PR DESCRIPTION
The layout is expected to be in a multiple of three for it to display
properly and without that it breaks close to the bottom.

Fixes #166

**Before fix**
<img width="1317" alt="Screenshot 2020-10-21 at 09 31 31" src="https://user-images.githubusercontent.com/1377253/96694435-61a6e000-1380-11eb-9abb-85a0bc46b17b.png">

**After fix**
<img width="1321" alt="Screenshot 2020-10-21 at 09 32 22" src="https://user-images.githubusercontent.com/1377253/96694461-68355780-1380-11eb-975e-3b0daa861f89.png">
