### PR TITLE
enable html5 on splitscreen demo

### DIFF
--- a/src/documents/demos/SplitScreen.html.md
+++ b/src/documents/demos/SplitScreen.html.md
@@ -4,6 +4,7 @@ layout: demo
 width: 400
 height: 300
 source: "Features/SplitScreen"
+targets: ['flash', 'html5']
 ```
 
 A port and improvement of the [Split Screen demo](https://github.com/phmongeau/SplitScreen) by [Philippe Mongeau](https://twitter.com/phmongeau) featured on [flixel.org/features](http://flixel.org/features.html).


### PR DESCRIPTION
https://github.com/HaxeFlixel/flixel-demos/issues/281

 I didn't change anything on the final line, I think github did that