### PR TITLE
proper scaling for mobile on showcases page

### DIFF
--- a/src/documents/showcase.html.eco
+++ b/src/documents/showcase.html.eco
@@ -17,7 +17,7 @@ layout: showcases
 
 		<a class="showcase-game-thumbnail" href="<%= showcase.website %>" property="dc:title" target="_blank">
 
-			<img width="500" height="260" src="<%= @getThumbnail("/images/showcase/#{showcase.title}.png", "zoomcrop", { w: 500, h: 260 }) %>"
+			<img src="<%= @getThumbnail("/images/showcase/#{showcase.title}.png", "zoomcrop", { w: 500, h: 260 }) %>"
 				alt="<%= showcase.title %>" title="<%= showcase.website %>">
 
 		</a>

--- a/src/documents/styles/sections/showcase.less
+++ b/src/documents/styles/sections/showcase.less
@@ -18,6 +18,9 @@
 }
 .showcase-game-thumbnail img {
   .box-shadow(~"0 1px 5px #696969, 0 -2px 5px #F2F2F2");
+  width: 100%;
+  max-width: 500px;
+  height: auto;
 }
 
 .showcase-game {


### PR DESCRIPTION
adds proper scaling to the thumbnails on the showcases page

affects MOBILE views

before
![img](https://cdn.discordapp.com/attachments/506919798291038213/1181349296583491664/image.png?ex=6580bc44&is=656e4744&hm=7abc4a09171b29504512094cae7db6abe6bb8aa949d87e19f2db0b17e8c80574&)

after
![igm](https://cdn.discordapp.com/attachments/506919798291038213/1181349362786369637/image.png?ex=6580bc54&is=656e4754&hm=e1eaae01b73df521ece8b121bca8c24ff476c52797da2c1c727d02de4b39190f&)