### PR TITLE
Game Showcase Section + Additional Fixes

### DIFF
--- a/content/_layouts/demos-layout.liquid
+++ b/content/_layouts/demos-layout.liquid
@@ -1,17 +1,19 @@
 ---
 layout: default.liquid
 ---
-<h1 class="title ">{{ title }} 
-<div class="float-end">
-	<a
-	class="github-button"
-	href="https://github.com/haxeflixel/flixel-demos"
-	data-color-scheme="no-preference: light_high_contrast; light: light_high_contrast; dark: dark_high_contrast;"
-	data-size="large"
-	data-show-count="true"
-	aria-label="Star haxeflixel/flixel on GitHub"
-	>haxeflixel/flixel-demos</a>
-</div>	
- </h1>
+<h1 class="title ">
+	{{ title }}
+	<div class="float-end">
+		<a
+			class="github-button"
+			href="https://github.com/haxeflixel/flixel-demos"
+			data-color-scheme="no-preference: light_high_contrast; light: light_high_contrast; dark: dark_high_contrast;"
+			data-size="large"
+			data-show-count="true"
+			aria-label="Star haxeflixel/flixel on GitHub"
+			>haxeflixel/flixel-demos</a
+		>
+	</div>
+</h1>
 
 {{ content }}

--- a/content/_layouts/documentation-layout.liquid
+++ b/content/_layouts/documentation-layout.liquid
@@ -1,20 +1,21 @@
 ---
 layout: default
 ---
-<h1 class="title">{{ title }}
+<h1 class="title">
+	{{ title }}
 
-<div class="float-end">
-	<a
-	class="github-button"
-	href="https://github.com/haxeflixel/flixel-docs"
-	data-color-scheme="no-preference: light_high_contrast; light: light_high_contrast; dark: dark_high_contrast;"
-	data-size="large"
-	data-show-count="true"
-	aria-label="Star haxeflixel/flixel on GitHub"
-	>haxeflixel/flixel-docs</a>
-</div>	
+	<div class="float-end">
+		<a
+			class="github-button"
+			href="https://github.com/haxeflixel/flixel-docs"
+			data-color-scheme="no-preference: light_high_contrast; light: light_high_contrast; dark: dark_high_contrast;"
+			data-size="large"
+			data-show-count="true"
+			aria-label="Star haxeflixel/flixel on GitHub"
+			>haxeflixel/flixel-docs</a
+		>
+	</div>
 </h1>
-
 
 <p>
 	The HaxeFlixel documentation is provided from the

--- a/content/_layouts/partials/footer.liquid
+++ b/content/_layouts/partials/footer.liquid
@@ -6,27 +6,27 @@
 					<ul class="list-unstyled">
 						<li>
 							<a href="https://twitter.com/haxeflixel">
-								Twitter
 								<i class="bi-twitter"></i>
+								Twitter
 							</a>
 						</li>
 						<li>
 							<a href="https://github.com/haxeflixel">
-								Github
 								<i class="bi-github"></i>
+								GitHub
 							</a>
 						</li>
 						<li>
 							<a href="https://discordapp.com/invite/rqEBAgF">
-								Discord
 								<i class="bi-discord"></i>
+								Discord
 							</a>
 						</li>
 						<li >
-							<a href="https://www.patreon.com/haxefliexel">
-								Patreon
+							<a href="https://www.patreon.com/haxeflixel">
 								<img class="footer-patreon" src="/images/patreon-logo.svg"
-									width="16px"/>
+								width="16px"/>
+								Patreon
 							</a>
 						</li>
 					</ul>

--- a/content/_layouts/partials/footer.liquid
+++ b/content/_layouts/partials/footer.liquid
@@ -22,10 +22,12 @@
 								Discord
 							</a>
 						</li>
-						<li >
+						<li>
 							<a href="https://www.patreon.com/haxeflixel">
-								<img class="footer-patreon" src="/images/patreon-logo.svg"
-								width="16px"/>
+								<img
+									class="footer-patreon"
+									src="/images/patreon-logo.svg"
+									width="16px">
 								Patreon
 							</a>
 						</li>
@@ -45,7 +47,6 @@
 							<li>
 								<a href="https://api.haxeflixel.com">API</a>
 							</li>
-							
 						</ul>
 						<ul class="list-unstyled col">
 							<li>
@@ -59,8 +60,6 @@
 							</li>
 						</ul>
 					</div>
-
-					
 				</div>
 
 				<div class="footer-powered-by col ">

--- a/content/_layouts/showcase.liquid
+++ b/content/_layouts/showcase.liquid
@@ -5,15 +5,16 @@ layout: default
 	{{ title }}
 
 	<div class="float-end">
-	<a
-	class="github-button"
-	href="https://github.com/haxeflixel/haxeflixel.com?tab=readme-ov-file#how-to-add-a-showcase-game"
-	data-color-scheme="no-preference: light_high_contrast; light: light_high_contrast; dark: dark_high_contrast;"
-	data-size="large"
-	data-show-count="true"
-	aria-label="Star haxeflixel/flixel on GitHub"
-	>haxeflixel/haxeflixel.com</a>
-	</div>	
+		<a
+			class="github-button"
+			href="https://github.com/haxeflixel/haxeflixel.com?tab=readme-ov-file#how-to-add-a-showcase-game"
+			data-color-scheme="no-preference: light_high_contrast; light: light_high_contrast; dark: dark_high_contrast;"
+			data-size="large"
+			data-show-count="true"
+			aria-label="Star haxeflixel/flixel on GitHub"
+			>haxeflixel/haxeflixel.com</a
+		>
+	</div>
 </h1>
 
 {{ content }}

--- a/content/_scss/sections/home.scss
+++ b/content/_scss/sections/home.scss
@@ -15,6 +15,7 @@
 	font-size: 30px;
 	font-weight: 200;
 	padding-bottom: 30px;
+	padding-top: 10px;
 }
 
 .lead-line-large {
@@ -80,10 +81,20 @@
 	box-shadow: var(--bs-box-shadow);
 }
 
+.games-home .showcase-list {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-evenly;
+}
+
+.games-home a {
+	margin: 0.5em;
+	gap: 0.25em;
+}
+
 .platform-logos-home img {
 	padding: 10px;
 	@include opacityAll(0.7);
-	@include hover-scale-fx(1.1);
 	@include grayscale();
 }
 
@@ -94,16 +105,6 @@ $color-mode-type: data;
 		@include opacityAll(1);
 		filter: invert(0.7);
 	}
-
-	.platform-logos-home img:hover {
-		@include opacityAll(1);
-		filter: invert(0.9);
-	}
-}
-
-.platform-logos-home img:hover {
-	@include opacityAll(1);
-	@include nograyscale();
 }
 
 .platform-demos-home img {
@@ -117,6 +118,7 @@ $color-mode-type: data;
 
 .home-big-logo img {
 	@include hover-scale-fx(1.1);
+	padding-bottom: 15px;
 }
 
 .navbar-fixed-top {

--- a/content/demos.liquid
+++ b/content/demos.liquid
@@ -4,7 +4,6 @@ layout: "demos-layout"
 ---
 <div class="demo-page center-align-a row row-cols-sm-2 row-cols-3 g-3 justify-content-center mx-sm-4">
 	{% for demo in collections['demo-item'] %}
-		
 		<a
 			class="col-6 col-sm-4 col-md-3"
 			href="{{ demo.url }}">

--- a/content/index.liquid
+++ b/content/index.liquid
@@ -21,10 +21,9 @@ title: 'Home'
 			All with one codebase.
 		</p>
 
-		<div 
+		<div
 			class="d-flex justify-content-center"
-			style="gap: 2em"
-		>
+			style="gap: 2em">
 			<a
 				role="button"
 				class="btn btn-outline-primary btn-lg"
@@ -35,8 +34,7 @@ title: 'Home'
 			<a
 				role="button"
 				class="btn btn-outline-primary btn-lg"
-				href="https://github.com/HaxeFlixel"
-				>
+				href="https://github.com/HaxeFlixel">
 				<i class="bi-github"></i>
 				GitHub
 			</a>
@@ -131,7 +129,7 @@ title: 'Home'
 				<a href="/demos">{{ collections['demo-item'].length }} demos</a>:
 			</p>
 		</h3>
-		
+
 		{% for demo in collections.homepage_demo %}
 			<a href="{{ demo.url }}" property="dc:title">
 				{% capture imgURL %}content/_static/images/demos/{{ demo.data.title }}.png{% endcapture %}
@@ -146,9 +144,7 @@ title: 'Home'
 
 	<div class="games-home home-section">
 		<h3>
-			<p class="lead-line-large">
-				These popular games use HaxeFlixel:
-			</p>
+			<p class="lead-line-large">These popular games use HaxeFlixel:</p>
 		</h3>
 
 		<div class="showcase-list">
@@ -156,92 +152,92 @@ title: 'Home'
 				{% if showcase.data.featured %}
 					<a href="{{showcase.data.website}}">
 						{% capture imgURL %}content/_static/images/showcase/{{showcase.fileSlug}}.png{% endcapture %}
-							{% liquid
-								image imgURL, showcase.data.title, 250, 130
-							%}
+						{% liquid
+							image imgURL, showcase.data.title, 250, 130
+						%}
 					</a>
 				{% endif %}
 			{% endfor %}
-	</div>
-
-	<hr>
-
-	<div class="home-section-powered">
-		<p class="lead-line-large">Powered by open source cross-platform tech:</p>
-
-		<br>
-		<div class="row my-auto g-0 align-items-center justify-content-evenly">
-			<a  class="col-2"
-			href="https://haxe.org"
-			data-bs-toggle="tooltip"
-			data-bs-title="Default tooltip"
-			><img
-				src="/images/haxe.svg"
-				alt="Haxe Logo"
-				title="Haxe"
-			></a>
-			<span class="col-1">
-				<b>+</b>
-			</span> 
-			<a class="col-2" href="https://openfl.org"
-				><img
-				src="/images/openfl.svg"
-				alt="OpenFL Logo"
-				title="OpenFL"
-			></a>
-
-		<span class="col-1">
-			<b>+</b>
-		</span> 
-
-		<a class="col-2" href="https://flixel.org"
-			><img
-				src="/images/flixel.svg"
-				alt="Flixel Logo"
-				title="Flixel"
-		></a>
-
-		<span class="col-1">
-			<b>=</b>
-		</span> 
-
-		<a class="col-2" href="https://haxeflixel.com">
-			<img
-				src="/images/haxeflixel.svg"
-				alt="HaxeFlixel logo"
-				title="HaxeFlixel"
-				>
-		</a>
-
-		</div>
-		<br>
-	</div>
-
-	<hr>
-
-	<div class="home-sponsor-logos">
-		<p class="lead-line-large">Our platinum and gold sponsors:</p>
-
-		<div class="sponsor-logos-container">
-			<a class="platinum" href="http://www.defendersquest.com">
-				<img src="/images/sponsors/platinum/level-up-labs/lul_logo_circle.png">
-			</a>
-
-			<a class="platinum" href="http://bluebottlegames.com">
-				<img src="/images/sponsors/platinum/blue-bottle-games/bbgLogoColor256x256.png">
-			</a>
-
-			<a class="gold" href="http://www.kongregate.com">
-				<img src="/images/sponsors/gold/kongregate/kongregate_anthill.svg">
-			</a>
-
-			<a class="gold" href="http://www.solarpoweredgames.de">
-				<img src="/images/sponsors/gold/solar-powered/logo-solarpoweredgames-inverted-256.png">
-			</a>
 		</div>
 
-		<br>
+		<hr>
 
-		<a class="btn btn-primary btn-lg" href="/sponsors"> See all our Sponsors </a>
+		<div class="home-section-powered">
+			<p class="lead-line-large">Powered by open source cross-platform tech:</p>
+
+			<br>
+			<div class="row my-auto g-0 align-items-center justify-content-evenly">
+				<a
+					class="col-2"
+					href="https://haxe.org"
+					data-bs-toggle="tooltip"
+					data-bs-title="Default tooltip"
+					><img
+						src="/images/haxe.svg"
+						alt="Haxe Logo"
+						title="Haxe"
+				></a>
+				<span class="col-1">
+					<b>+</b>
+				</span>
+				<a class="col-2" href="https://openfl.org"
+					><img
+						src="/images/openfl.svg"
+						alt="OpenFL Logo"
+						title="OpenFL"
+				></a>
+
+				<span class="col-1">
+					<b>+</b>
+				</span>
+
+				<a class="col-2" href="https://flixel.org"
+					><img
+						src="/images/flixel.svg"
+						alt="Flixel Logo"
+						title="Flixel"
+				></a>
+
+				<span class="col-1">
+					<b>=</b>
+				</span>
+
+				<a class="col-2" href="https://haxeflixel.com">
+					<img
+						src="/images/haxeflixel.svg"
+						alt="HaxeFlixel logo"
+						title="HaxeFlixel">
+				</a>
+			</div>
+			<br>
+		</div>
+
+		<hr>
+
+		<div class="home-sponsor-logos">
+			<p class="lead-line-large">Our platinum and gold sponsors:</p>
+
+			<div class="sponsor-logos-container">
+				<a class="platinum" href="http://www.defendersquest.com">
+					<img src="/images/sponsors/platinum/level-up-labs/lul_logo_circle.png">
+				</a>
+
+				<a class="platinum" href="http://bluebottlegames.com">
+					<img src="/images/sponsors/platinum/blue-bottle-games/bbgLogoColor256x256.png">
+				</a>
+
+				<a class="gold" href="http://www.kongregate.com">
+					<img src="/images/sponsors/gold/kongregate/kongregate_anthill.svg">
+				</a>
+
+				<a class="gold" href="http://www.solarpoweredgames.de">
+					<img src="/images/sponsors/gold/solar-powered/logo-solarpoweredgames-inverted-256.png">
+				</a>
+			</div>
+
+			<br>
+
+			<a class="btn btn-primary btn-lg" href="/sponsors"> See all our Sponsors </a>
+		</div>
 	</div>
 </div>

--- a/content/index.liquid
+++ b/content/index.liquid
@@ -21,20 +21,24 @@ title: 'Home'
 			All with one codebase.
 		</p>
 
-		<div class="d-flex justify-content-around">
+		<div 
+			class="d-flex justify-content-center"
+			style="gap: 2em"
+		>
 			<a
 				role="button"
 				class="btn btn-outline-primary btn-lg"
 				href="/documentation/getting-started"
-				>Getting Started
-				<i class="bi-list-ol"></i>
+				><i class="bi-list-ol"></i>
+				Getting Started
 			</a>
 			<a
 				role="button"
 				class="btn btn-outline-primary btn-lg"
 				href="https://github.com/HaxeFlixel"
-				>GitHub
+				>
 				<i class="bi-github"></i>
+				GitHub
 			</a>
 		</div>
 
@@ -140,6 +144,28 @@ title: 'Home'
 
 	<hr>
 
+	<div class="games-home home-section">
+		<h3>
+			<p class="lead-line-large">
+				These popular games use HaxeFlixel:
+			</p>
+		</h3>
+
+		<div class="showcase-list">
+			{% for showcase in collections['showcase-item'] reversed %}
+				{% if showcase.data.featured %}
+					<a href="{{showcase.data.website}}">
+						{% capture imgURL %}content/_static/images/showcase/{{showcase.fileSlug}}.png{% endcapture %}
+							{% liquid
+								image imgURL, showcase.data.title, 250, 130
+							%}
+					</a>
+				{% endif %}
+			{% endfor %}
+	</div>
+
+	<hr>
+
 	<div class="home-section-powered">
 		<p class="lead-line-large">Powered by open source cross-platform tech:</p>
 
@@ -188,16 +214,6 @@ title: 'Home'
 		</a>
 
 		</div>
-		
-
-		
-
-		
-
-		
-
-		
-
 		<br>
 	</div>
 


### PR DESCRIPTION
This PR addresses some of the suggestions that @SeiferTim wanted

Not sure if a preview is needed, though I created one :)

- Reduced spacing on the "Getting Started" and "GitHub" buttons
- Adjusted margins on HaxeFlixel logo to be further
- Icons on Buttons are placed on the left rather than the right, to be consistent with the shields.io buttons
- Game Showcase Section

https://github.com/HaxeFlixel/haxeflixel.com/assets/71162374/dc231921-c99a-4dc3-ba4b-4abd2ab448ad

