### PR TITLE
add fullscreen button to demos

### DIFF
--- a/content/_layouts/demo.liquid
+++ b/content/_layouts/demo.liquid
@@ -10,12 +10,18 @@ layout: default.liquid
 		{% unless width %}
 			{% assign width = 640 %}
 		{% endunless %}
-
-		<iframe
-			class="html5-demo"
-			src="https://demos.haxeflixel.com/html5/{{title}}"
-			width="{{width}}"
-			height="{{height}}"></iframe>
+		<div class="position-relative" style="height: {{height}}; width={{width}}">
+			<iframe
+				class="html5-demo"
+				src="https://demos.haxeflixel.com/html5/{{title}}"
+				width="{{width}}"
+				height="{{height}}" allowfullscreen></iframe>
+			<button type="button" class="btn btn-outline-primary position-absolute bottom-0 end-0" onclick="toggleFullscreen();">
+				<i class="bi bi-arrows-fullscreen"></i>
+				</button>
+				
+		</div>
+		
 	{% endif %}
 
 	{% if targets == 'flash' %}
@@ -102,6 +108,14 @@ layout: default.liquid
 	</div>
 </div>
 
+<script type="text/javascript">
+function toggleFullscreen()
+{
+	let iframe = document.querySelector('.html5-demo');
+	iframe.requestFullscreen();
+}
+</script>
+
 {% if targets == 'flash' %}
-	<script type="text/javascript" src="/vendor/swfobject/swfobject/swfobject.js"></script>
+	{% comment %} <script type="text/javascript" src="/vendor/swfobject/swfobject/swfobject.js"></script> {% endcomment %}
 {% endif %}

--- a/content/_layouts/demo.liquid
+++ b/content/_layouts/demo.liquid
@@ -11,18 +11,18 @@ layout: default.liquid
 			{% assign width = 640 %}
 		{% endunless %}
 
-			<button type="button" class="btn btn-outline-primary position-absolute bottom-0 end-0 m-2" onclick="toggleFullscreen();">
-				<i class="bi bi-arrows-fullscreen"></i>
-				</button>
-			<iframe
-				class="html5-demo"
-				src="https://demos.haxeflixel.com/html5/{{title}}"
-				width="{{width}}"
-				height="{{height}}" allow="fullscreen"></iframe>
-			
-				
-
-		
+		<button
+			type="button"
+			class="btn btn-outline-primary position-absolute bottom-0 end-0 m-2"
+			onclick="toggleFullscreen();">
+			<i class="bi bi-arrows-fullscreen"></i>
+		</button>
+		<iframe
+			class="html5-demo"
+			src="https://demos.haxeflixel.com/html5/{{title}}"
+			width="{{width}}"
+			height="{{height}}"
+			allow="fullscreen"></iframe>
 	{% endif %}
 
 	{% if targets == 'flash' %}
@@ -110,11 +110,10 @@ layout: default.liquid
 </div>
 
 <script type="text/javascript">
-function toggleFullscreen()
-{
-	let iframe = document.querySelector('.html5-demo');
-	iframe.requestFullscreen();
-}
+	function toggleFullscreen() {
+		let iframe = document.querySelector('.html5-demo');
+		iframe.requestFullscreen();
+	}
 </script>
 
 {% if targets == 'flash' %}

--- a/content/_layouts/demo.liquid
+++ b/content/_layouts/demo.liquid
@@ -1,7 +1,7 @@
 ---
 layout: default.liquid
 ---
-<div class="demo-container">
+<div class="demo-container position-relative mx-auto" style="width: fit-content;">
 	{% if targets == 'html5' %}
 		{% unless height %}
 			{% assign height = 480 %}
@@ -10,17 +10,18 @@ layout: default.liquid
 		{% unless width %}
 			{% assign width = 640 %}
 		{% endunless %}
-		<div class="position-relative" style="height: {{height}}; width={{width}}">
+
+			<button type="button" class="btn btn-outline-primary position-absolute bottom-0 end-0 m-2" onclick="toggleFullscreen();">
+				<i class="bi bi-arrows-fullscreen"></i>
+				</button>
 			<iframe
 				class="html5-demo"
 				src="https://demos.haxeflixel.com/html5/{{title}}"
 				width="{{width}}"
-				height="{{height}}" allowfullscreen></iframe>
-			<button type="button" class="btn btn-outline-primary position-absolute bottom-0 end-0" onclick="toggleFullscreen();">
-				<i class="bi bi-arrows-fullscreen"></i>
-				</button>
+				height="{{height}}" allow="fullscreen"></iframe>
+			
 				
-		</div>
+
 		
 	{% endif %}
 

--- a/content/scripts.njk
+++ b/content/scripts.njk
@@ -9,3 +9,7 @@ function copyAnchorLink() {
 	else
 		console.log("Clipboard API not supported");
 }
+
+
+
+


### PR DESCRIPTION
closes issue from https://github.com/HaxeFlixel/flixel-demos/issues/322 (only closes it fully once PR https://github.com/HaxeFlixel/flixel-demos/pull/336 in `flixel-demos` is merged!)

adds a fullscreen button that fullscreens the iframe of a demo