### PR TITLE
Fix horizontal scroll caused by logo color line

### DIFF
--- a/content/_layouts/blog-layout.liquid
+++ b/content/_layouts/blog-layout.liquid
@@ -3,7 +3,10 @@ layout: default.liquid
 ---
 <div class="row">
 	<div class="col-md-8">
-		<h1 class="title">{{ title }} <a class="float-end link-body-emphasis" href="/feed.xml"><i class="h4 bi bi-rss"></i></a></h1>
+		<h1 class="title">
+			{{ title }}
+			<a class="float-end link-body-emphasis" href="/feed.xml"><i class="h4 bi bi-rss"></i></a>
+		</h1>
 		{{ content }}
 	</div>
 

--- a/content/_layouts/partials/footer.liquid
+++ b/content/_layouts/partials/footer.liquid
@@ -1,4 +1,4 @@
-<footer>
+<footer class="container-fluid">
 	{% renderFile "./content/_layouts/partials/hf-splash-line.liquid" %}
 
 	<div class="footer-main py-3 mt-5">
@@ -58,7 +58,7 @@
 								<a href="/showcase">Showcase</a>
 							</li>
 							<li>
-								<a href="/blog">Blog</a> 
+								<a href="/blog">Blog</a>
 								<a class="ms-1" href="/feed.xml"><i class="fw-lighter bi bi-rss"></i></a>
 							</li>
 						</ul>


### PR DESCRIPTION
The HaxeFlixel website currently causes a horizontal scroll bar to popup. This is caused by the logo color line (a Bootstrap row) at the bottom of the page not being in a container.

The Bootstrap documentation mentions how the grid system must be used in a container:
> Containers are the most basic layout element in Bootstrap and are **required when using our default grid system.**
https://getbootstrap.com/docs/4.6/layout/overview/#containers